### PR TITLE
Add filter for duplicate credible sets

### DIFF
--- a/susieinf/susieinf.py
+++ b/susieinf/susieinf.py
@@ -207,7 +207,7 @@ def susie(z,meansq,n,L,LD=None,V=None,Dsq=None,
   return {'PIP':PIP, 'mu':mu, 'omega':omega, 'ssq':ssq,
     'sigmasq':sigmasq, 'tausq':tausq, 'alpha': alpha}
 
-def cred(PIP,coverage=0.9,purity=0.5,LD=None,V=None,Dsq=None,n=None):
+def cred(PIP,coverage=0.9,purity=0.5,LD=None,V=None,Dsq=None,n=None,dedup=True):
   ''' Compute credible sets from single-effect PIPs
 
   PIP -- p x L PIP matrix output by susie
@@ -218,6 +218,7 @@ def cred(PIP,coverage=0.9,purity=0.5,LD=None,V=None,Dsq=None,n=None):
   V -- precomputed p x p matrix of eigenvectors of X'X
   Dsq -- precomputed length-p vector of eigenvalues of X'X
   n -- sample size
+  dedup -- remove duplicate CS's
   (Must provide either LD or the triple (V,Dsq,n), to do purity filtering)
 
   Returns: list of variable indices corresponding to credible sets
@@ -244,6 +245,9 @@ def cred(PIP,coverage=0.9,purity=0.5,LD=None,V=None,Dsq=None,n=None):
     else:
       LDloc = (V[rows,:]*Dsq).dot(V[rows,:].T)/n
     if np.min(np.abs(LDloc)) > purity:
+      if dedup:
+        cred = list(map(list, sorted(set(map(tuple, cred)), 
+                                     key=list(map(tuple, cred)).index)))
       cred.append(sorted(list(credset)))
   return cred
 

--- a/susieinf/susieinf.py
+++ b/susieinf/susieinf.py
@@ -245,9 +245,8 @@ def cred(PIP,coverage=0.9,purity=0.5,LD=None,V=None,Dsq=None,n=None,dedup=True):
     else:
       LDloc = (V[rows,:]*Dsq).dot(V[rows,:].T)/n
     if np.min(np.abs(LDloc)) > purity:
-      if dedup:
-        cred = list(map(list, sorted(set(map(tuple, cred)), 
-                                     key=list(map(tuple, cred)).index)))
       cred.append(sorted(list(credset)))
+  if dedup:
+    cred = list(map(list, sorted(set(map(tuple, cred)), key=list(map(tuple, cred)).index)))
   return cred
 


### PR DESCRIPTION
The current implementation of `cred` can return duplicate credible sets.

Reference to the original issue in susieR: https://github.com/stephenslab/susieR/issues/21
Equivalent line in `susie_get_cs`: https://github.com/stephenslab/susieR/blob/648de3ca8fd0ff2c57d982c6a8619d0f50057ff1/R/susie_utils.R#L291